### PR TITLE
Use strcasecmp instead of strcmp to identify tests specified on the c…

### DIFF
--- a/mpiBench.c
+++ b/mpiBench.c
@@ -431,7 +431,7 @@ int processArgs(int argc, char **argv, struct argList* args)
     /* turn on test flags requested by user
        if user doesn't specify any, all will be run */
     for(j=0; j<NUM_TESTS; j++) {
-      if(!strcmp(TEST_NAMES[j], argv[i])) {
+      if(!strcasecmp(TEST_NAMES[j], argv[i])) {
         if(args->testFlags == 0x1FFF) args->testFlags = 0;
         args->testFlags |= TEST_FLAGS[j];
       }


### PR DESCRIPTION
Use strcasecmp instead of strcmp to identify tests specified on the command
line by user. With this change, users will be able to mention "Alltoall" or
"alltoall" instead of being forced to specify "Alltoall".
